### PR TITLE
Add twitch name colors to minecraft chat

### DIFF
--- a/src/main/java/me/mini_bomba/streamchatmod/runnables/TwitchMessageHandler.java
+++ b/src/main/java/me/mini_bomba/streamchatmod/runnables/TwitchMessageHandler.java
@@ -8,6 +8,7 @@ import me.mini_bomba.streamchatmod.StreamChatMod;
 import me.mini_bomba.streamchatmod.StreamUtils;
 import me.mini_bomba.streamchatmod.utils.ChatComponentStreamEmote;
 import me.mini_bomba.streamchatmod.utils.ChatComponentTwitchMessage;
+import me.mini_bomba.streamchatmod.utils.ColorUtil;
 import net.minecraft.event.ClickEvent;
 import net.minecraft.event.HoverEvent;
 import net.minecraft.util.ChatComponentText;
@@ -21,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
 public class TwitchMessageHandler implements Runnable {
     private final ChannelMessageEvent event;
@@ -132,7 +134,8 @@ public class TwitchMessageHandler implements Runnable {
         List<ClipComponentMapping> clips = new ArrayList<>();
         IChatComponent component = new ChatComponentTwitchMessage(event.getMessageEvent().getMessageId().orElse(""), event.getChannel().getId(), event.getUser().getId(), (showChannel ? mod.config.getTwitchPrefixWithChannel(event.getChannel().getName()) : mod.config.getFullTwitchPrefix()) + " ");
         if (badges.getSiblings().size() > 0) component.appendSibling(badges);
-        component.appendSibling(new ChatComponentText((badges.getSiblings().size() > 0 ? " " : "") + EnumChatFormatting.WHITE + event.getUser().getName() + " " + mod.config.getTwitchUserMessageSeparator() + " "));
+
+        component.appendSibling(new ChatComponentText((badges.getSiblings().size() > 0 ? " " : "") + ColorUtil.getColorFromHex(event.getMessageEvent().getTagValue("color").orElse("#FFFFFF")) + event.getUser().getName() + " " + mod.config.getTwitchUserMessageSeparator() + " "));
         int lastEnd = 0;
         while (matcher.find()) {
             if (matcher.start() > lastEnd)
@@ -233,4 +236,6 @@ public class TwitchMessageHandler implements Runnable {
         }
         return component;
     }
+
+
 }

--- a/src/main/java/me/mini_bomba/streamchatmod/utils/ColorUtil.java
+++ b/src/main/java/me/mini_bomba/streamchatmod/utils/ColorUtil.java
@@ -1,0 +1,58 @@
+package me.mini_bomba.streamchatmod.utils;
+
+import net.minecraft.util.EnumChatFormatting;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.stream.IntStream;
+
+public class ColorUtil {
+
+	private static Map<Integer, EnumChatFormatting> colors = new HashMap<>();
+
+	static {
+		colors.put(0xAA0000, EnumChatFormatting.DARK_RED);
+		colors.put(0xFF5555, EnumChatFormatting.RED);
+		colors.put(0xFFAA00, EnumChatFormatting.GOLD);
+		colors.put(0xFFFF55, EnumChatFormatting.YELLOW);
+		colors.put(0x00AA00, EnumChatFormatting.DARK_GREEN);
+		colors.put(0x55FF55, EnumChatFormatting.GREEN);
+		colors.put(0x55FFFF, EnumChatFormatting.AQUA);
+		colors.put(0x00AAAA, EnumChatFormatting.DARK_AQUA);
+		colors.put(0x0000AA, EnumChatFormatting.DARK_BLUE);
+		colors.put(0x5555FF, EnumChatFormatting.BLUE);
+		colors.put(0xFF55FF, EnumChatFormatting.LIGHT_PURPLE);
+		colors.put(0xAA00AA, EnumChatFormatting.DARK_PURPLE);
+		colors.put(0xFFFFFF, EnumChatFormatting.WHITE);
+		colors.put(0xAAAAAA, EnumChatFormatting.GRAY);
+		colors.put(0x555555, EnumChatFormatting.DARK_GRAY);
+		colors.put(0x000000, EnumChatFormatting.BLACK);
+	}
+
+	public static EnumChatFormatting getColorFromHex(String hex) {
+		int color = Integer.decode(hex);
+		return colors.get(getNearestColor(color));
+	}
+
+	private static int getNearestColor( int color) {
+		int[] colorsarr = Arrays.stream(colors.keySet().toArray(new Integer[0])).mapToInt(Integer::intValue).toArray();
+
+
+		int minDiff = IntStream.of(colorsarr)
+						.map(val -> Math.abs(val - color))
+						.min()
+						.getAsInt();
+
+		OptionalInt num = IntStream.of(colorsarr)
+						.filter(val-> val==(color + minDiff))
+						.findFirst();
+
+		if(num.isPresent()){
+			return color + minDiff;
+		} else {
+			return color - minDiff;
+		}
+	}
+}


### PR DESCRIPTION
![Twitch preview](https://i.imgur.com/x9v3tE2.png)
![Minecraft preview](https://i.imgur.com/f1iPKLq.png)

Because HEX colors were added to the Minecraft client in 1.16, I've had to make a bit of a hack that finds the nearest "native" minecraft color and displays that instead. This may not be accurate all the time, but every user will have the same color every time. (unless they change it, obviously). This will improve usability by a lot as you can more easily distinguish between users.